### PR TITLE
Changing the Casper Suite pkg recipe.

### DIFF
--- a/Casper Suite/Casper Suite.jss.recipe
+++ b/Casper Suite/Casper Suite.jss.recipe
@@ -28,7 +28,7 @@
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.scriptingosx.pkg.CasperSuite</string>
+	<string>com.github.novaksam.pkg.CasperSuite</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
The novaksam Casper Suite recipe contains a postinstall script that’ll
repair the folder icon.