### PR TITLE
Update Adobe Acrobat Pro.jss.recipe

### DIFF
--- a/Adobe Acrobat Pro/Adobe Acrobat Pro.jss.recipe
+++ b/Adobe Acrobat Pro/Adobe Acrobat Pro.jss.recipe
@@ -16,8 +16,6 @@
 		<string>SmartGroupTemplate.xml</string>
 		<key>NAME</key>
 		<string>Adobe Acrobat Pro</string>
-		<key>OS_REQUIREMENTS</key>
-		<string>10.11.x,10.10.x,10.9.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>


### PR DESCRIPTION
Removing OS requirements since Acrobat XI can be installed on 10.6.8+ and Acrobat X can be installed on 10.5 or 10.6.