### PR TITLE
Updated OS_REQUIREMENTS for Chrome 50

### DIFF
--- a/Google Chrome/Google Chrome.jss.recipe
+++ b/Google Chrome/Google Chrome.jss.recipe
@@ -17,7 +17,7 @@
 		<key>NAME</key>
 		<string>Google Chrome</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.11.x,10.10.x,10.9.x</string>
+		<string>10.11.x,10.10.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>

--- a/Google Chrome/Google Chrome.jss.recipe
+++ b/Google Chrome/Google Chrome.jss.recipe
@@ -17,7 +17,7 @@
 		<key>NAME</key>
 		<string>Google Chrome</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.11.x,10.10.x</string>
+		<string>10.11.x,10.10.x,10.9.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>

--- a/Google Chrome/Google Chrome.jss.recipe
+++ b/Google Chrome/Google Chrome.jss.recipe
@@ -16,6 +16,8 @@
 		<string>SmartGroupTemplate.xml</string>
 		<key>NAME</key>
 		<string>Google Chrome</string>
+		<key>OS_REQUIREMENTS</key>
+		<string>10.11.x,10.10.x,10.9.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>


### PR DESCRIPTION
Added 
<key>OS_REQUIREMENTS</key>
<string>10.11.x,10.10.x, 10.9.x</string>

for Chrome 50: https://chrome.googleblog.com/2015/11/updates-to-chrome-platform-support.html