### PR TITLE
updated app name to 1Password 6

### DIFF
--- a/1Password/1Password.jss.recipe
+++ b/1Password/1Password.jss.recipe
@@ -17,7 +17,7 @@
 		<key>MAJOR_VERSION</key>
 		<string>6</string>
 		<key>NAME</key>
-		<string>1Password</string>
+		<string>1Password 6</string>
 		<key>OS_REQUIREMENTS</key>
 		<string>10.11.x,10.10.x</string>
 		<key>POLICY_CATEGORY</key>


### PR DESCRIPTION
Full app bundle and process name is now "1Password 6" which is required for [auto-update-magic](https://github.com/homebysix/auto-update-magic) to function.