### PR TITLE
fix for oracle jdk 8 extension attribute

### DIFF
--- a/Oracle Java 8 JDK/Oracle Java 8 JDKExtensionAttribute.xml
+++ b/Oracle Java 8 JDK/Oracle Java 8 JDKExtensionAttribute.xml
@@ -7,7 +7,7 @@
 		<platform>Mac</platform>
 		<script>#!/bin/bash
 
-OracleJava8JDKVersion=$(ls /Library/Java/JavaVirtualMachines | grep "jdk" | grep "1.8" | sed 's/.jdk//' | sed 's/jdk//' | sed -n '$p')
+OracleJava8JDKVersion=$(ls /Library/Java/JavaVirtualMachines | grep "jdk" | grep "1.8" | sed 's/.jdk//' | sed 's/jdk//' | sort -r | sed -n '$p')
 
 if [ "$OracleJava8JDKVersion" != "" ]; then
     echo "&lt;result&gt;$OracleJava8JDKVersion&lt;/result&gt;"


### PR DESCRIPTION
due to sorting error when the version went above 100, it's still returning 92 in the EA.