### PR TITLE
adding macOS Sierra to 1Password OS_REQUIREMENTS value

### DIFF
--- a/1Password/1Password.jss.recipe
+++ b/1Password/1Password.jss.recipe
@@ -19,7 +19,7 @@
 		<key>NAME</key>
 		<string>1Password</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.11.x,10.10.x</string>
+		<string>10.12.x,10.11.x,10.10.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>


### PR DESCRIPTION
Adding macOS Sierra to 1Password `OS_REQUIREMENTS` value.