### PR TITLE
Update Adobe Reader.jss.recipe

### DIFF
--- a/Adobe Reader/Adobe Reader.jss.recipe
+++ b/Adobe Reader/Adobe Reader.jss.recipe
@@ -36,6 +36,17 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+				<key>source_pkg</key>
+				<string>%pkg_path%</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgCopier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>category</key>
 				<string>%CATEGORY%</string>
 				<key>groups</key>


### PR DESCRIPTION
Change the pkg name from something along the lines of Adobe Reader XI Installer.pkg to Adobe Reader XI-version.pkg	which more closely matches existing recipes.