### PR TITLE
fixes issue in EA where the sorting of the versions does not work

### DIFF
--- a/Oracle Java 8 JDK/Oracle Java 8 JDKExtensionAttribute.xml
+++ b/Oracle Java 8 JDK/Oracle Java 8 JDKExtensionAttribute.xml
@@ -5,16 +5,24 @@
 	<input_type>
 		<type>script</type>
 		<platform>Mac</platform>
-		<script>#!/bin/bash
+		<script>#!/usr/bin/python
 
-OracleJava8JDKVersion=$(ls /Library/Java/JavaVirtualMachines | grep "jdk" | grep "1.8" | sed 's/.jdk//' | sed 's/jdk//' | sort -r | sed -n '$p')
+import os
 
-if [ "$OracleJava8JDKVersion" != "" ]; then
-    echo "&lt;result&gt;$OracleJava8JDKVersion&lt;/result&gt;"
-else
-    echo "&lt;result&gt;JDKNotInstalled&lt;/result&gt;"
-fi
-exit 0</script>
+jdk_dir = '/Library/Java/JavaVirtualMachines'
+
+if os.path.exists(jdk_dir) and os.listdir(jdk_dir):
+    d = {}
+    for jdk in os.listdir(jdk_dir):
+        version = os.path.splitext(jdk)[0][3:]
+        if '1.8.0' in version:
+            d[int(version.split('_')[1])] = version
+    if d:
+        print '&lt;result&gt;%s&lt;/result&gt;' % d[sorted(d.keys()).pop()]
+    else:
+        print '&lt;result&gt;JDKNotInstalled&lt;/result&gt;'
+else:
+    print '&lt;result&gt;JDKNotInstalled&lt;/result&gt;'</script>
 	</input_type>
 	<inventory_display>Extension Attributes</inventory_display>
 	<recon_display>Extension Attributes</recon_display>


### PR DESCRIPTION
The previous EA would sort the file listing like this:

$ ls /Library/Java/JavaVirtualMachines | grep "jdk" | grep "1.8" | sed 's/.jdk//' | sed 's/jdk//' | sort -r
1.8.0_92
1.8.0_111
1.8.0_101

Which would mean that 1.8.0_101 returns instead of 1.8.0_111.
