### PR TITLE
Update GitHub Desktop.jss.recipe

### DIFF
--- a/GitHub Desktop/GitHub Desktop.jss.recipe
+++ b/GitHub Desktop/GitHub Desktop.jss.recipe
@@ -17,7 +17,7 @@
 		<key>NAME</key>
 		<string>GitHub Desktop</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.12.x,10.11.x,10.10.x,10.9.x</string>
+		<string>10.13.x,10.12.x,10.11.x,10.10.x,10.9.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>


### PR DESCRIPTION
Updating OS requirements to support 10.13 High Sierra. Tested the package and confirmed it installs correctly on a 10.13 machines via JSS policy.