### PR TITLE
Updated iTerm2 Recipe's JSS_INVENTORY_NAME

### DIFF
--- a/iTerm2/iTerm2.jss.recipe
+++ b/iTerm2/iTerm2.jss.recipe
@@ -15,7 +15,7 @@
 		<key>GROUP_TEMPLATE</key>
 		<string>SmartGroupTemplate.xml</string>
 		<key>JSS_INVENTORY_NAME</key>
-		<string>iTerm</string>
+		<string>iTerm.app</string>
 		<key>NAME</key>
 		<string>iTerm2</string>
 		<key>POLICY_CATEGORY</key>


### PR DESCRIPTION
The smart group currently doesn't match the iTerm.app, so no computers are added.