### PR TITLE
Fix ParentRecipe

### DIFF
--- a/MySQLWorkBench/MySQLWorkBench.jss.recipe
+++ b/MySQLWorkBench/MySQLWorkBench.jss.recipe
@@ -30,7 +30,7 @@
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.autopkg.cgerke-recipes.pkg.MySQLWorkBench</string>
+	<string>com.github.autopkg.cgerke-recipes.pkg.MySQLWorkbench</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Fix for Issue #162. The parent recipe changed the casing of the name to match the casing in the actual app name, which has resulted in the JSS recipe not being able to find the parent and failing to run/make overrides/etc. Might also be worth updating the name of the JSS recipe/folder but I don't know what impact (though if no one has noticed this recipe is broken for that long maybe no one will care).