### PR TITLE
Adding the required pkg_path argument

### DIFF
--- a/Suspicious Package/Suspicious Package.jss.recipe
+++ b/Suspicious Package/Suspicious Package.jss.recipe
@@ -47,6 +47,8 @@
 						<string>%GROUP_TEMPLATE%</string>
 					</dict>
 				</array>
+				<key>pkg_path</key>
+				<string>%pkg_path%</string>
 				<key>policy_category</key>
 				<string>%POLICY_CATEGORY%</string>
 				<key>policy_template</key>


### PR DESCRIPTION
Parent Recipes were updated for new package distribution.
Updating to support those.