### PR TITLE
Update spotify-fix-permissions-postinstall.sh

### DIFF
--- a/Spotify/spotify-fix-permissions-postinstall.sh
+++ b/Spotify/spotify-fix-permissions-postinstall.sh
@@ -23,4 +23,6 @@ for EXECUTABLE in $(/usr/bin/find "${SPOTIFY_PATH}" -perm -u=x -type f); do
     fi
 done
 
+/bin/chmod -R go+rX "${SPOTIFY_PATH}"
+
 exit 0


### PR DESCRIPTION
Fix bug where ```/Applications/Spotify.app/Contents/Frameworks/Chromium Embedded Framework.framework``` has incorrect permissions.