### PR TITLE
updated OS_REQUIREMENTS for current Sketch build

### DIFF
--- a/Sketch/Sketch.jss.recipe
+++ b/Sketch/Sketch.jss.recipe
@@ -19,7 +19,7 @@
 		<key>NAME</key>
 		<string>Sketch</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.13.x,10.12.x,10.11.x,10.10.x</string>
+		<string>10.14.x,10.13.6,10.13.5,10.13.4</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>


### PR DESCRIPTION
Updated `OS_REQUIREMENTS` for current Sketch build (52.4 and later require macOS High Sierra 10.13.4 or newer and support macOS Mojave, according to https://www.sketchapp.com/support/requirements/system-requirements and https://blog.sketchapp.com/macos-mojave-brings-dark-mode-to-sketch-cccbf51f4164).