### PR TITLE
added JSS_INVENTORY_NAME definition

### DIFF
--- a/Zoom/Zoom.jss.recipe
+++ b/Zoom/Zoom.jss.recipe
@@ -8,14 +8,16 @@
 	<string>com.github.jss-recipes.jss.Zoom</string>
 	<key>Input</key>
 	<dict>
+		<key>NAME</key>
+		<string>Zoom</string>
+		<key>JSS_INVENTORY_NAME</key>
+		<string>zoom.us.app</string>
 		<key>CATEGORY</key>
 		<string>Productivity</string>
 		<key>GROUP_NAME</key>
 		<string>%NAME%-update-smart</string>
 		<key>GROUP_TEMPLATE</key>
 		<string>SmartGroupTemplate.xml</string>
-		<key>NAME</key>
-		<string>Zoom</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>
@@ -34,6 +36,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>prod_name</key>
+        			<string>%NAME%</string>
+        			<key>jss_inventory_name</key>
+        			<string>%JSS_INVENTORY_NAME%</string>
 				<key>category</key>
 				<string>%CATEGORY%</string>
 				<key>groups</key>
@@ -51,8 +57,6 @@
 				<string>%POLICY_CATEGORY%</string>
 				<key>policy_template</key>
 				<string>%POLICY_TEMPLATE%</string>
-				<key>prod_name</key>
-				<string>%NAME%</string>
 				<key>self_service_description</key>
 				<string>%SELF_SERVICE_DESCRIPTION%</string>
 				<key>self_service_icon</key>


### PR DESCRIPTION
Added JSS_INVENTORY_NAME definition to match the app bundle name of "zoom.us.app". Excluding this caused Auto Update Magic child recipes to incorrectly identify Application Title as "Zoom.app" in the autoupdate smart group, and never scope needed patches.