### PR TITLE
pkg_path fix for parent pkg recipe change

### DIFF
--- a/Proximity/Proximity.jss.recipe
+++ b/Proximity/Proximity.jss.recipe
@@ -53,6 +53,8 @@
 				<string>%POLICY_CATEGORY%</string>
 				<key>policy_template</key>
 				<string>%POLICY_TEMPLATE%</string>
+				<key>pkg_path</key>
+                    		<string>%pathname%</string>
 				<key>prod_name</key>
 				<string>%NAME%</string>
 				<key>self_service_description</key>

--- a/Sequel Pro/Sequel Pro.jss.recipe
+++ b/Sequel Pro/Sequel Pro.jss.recipe
@@ -51,6 +51,8 @@
 				<string>%POLICY_CATEGORY%</string>
 				<key>policy_template</key>
 				<string>%POLICY_TEMPLATE%</string>
+				<key>pkg_path</key>
+                    		<string>%pathname%</string>
 				<key>prod_name</key>
 				<string>%NAME%</string>
 				<key>self_service_description</key>


### PR DESCRIPTION
Got angry messages about JSSimporter requiring the missing argument pkg_path.