### PR TITLE
updated OS_REQUIREMENTS for 1Password 7

### DIFF
--- a/1Password/1Password.jss.recipe
+++ b/1Password/1Password.jss.recipe
@@ -14,12 +14,10 @@
 		<string>%NAME%-update-smart</string>
 		<key>GROUP_TEMPLATE</key>
 		<string>SmartGroupTemplate.xml</string>
-		<key>MAJOR_VERSION</key>
-		<string>6</string>
 		<key>NAME</key>
 		<string>1Password</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.13.x,10.12.x,10.11.x,10.10.x</string>
+		<string>10.14.x,10.13.x,10.12.6</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>


### PR DESCRIPTION
- updated OS_REQUIREMENTS for 1Password 7
- removed MAJOR_VERSION string (parent recipe only targets 1Password 7)