### PR TITLE
switched Zoom recipe to use CFBundleVersion

### DIFF
--- a/CFBundleVersionExtensionAttribute.xml
+++ b/CFBundleVersionExtensionAttribute.xml
@@ -1,5 +1,5 @@
 <computer_extension_attribute>
-	<name>%NAME%Version</name>
+	<name>%NAME% Version</name>
 	<description />
 	<data_type>String</data_type>
 	<input_type>

--- a/CFBundleVersionSmartGroupTemplate.xml
+++ b/CFBundleVersionSmartGroupTemplate.xml
@@ -10,14 +10,14 @@
 			<value>%JSS_INVENTORY_NAME%</value>
 		</criterion>
 		<criterion>
-			<name>%NAME%Version</name>
+			<name>%NAME% Version</name>
 			<priority>1</priority>
 			<and_or>and</and_or>
 			<search_type>is not</search_type>
 			<value>%VERSION%</value>
 		</criterion>
 		<criterion>
-			<name>%NAME%Version</name>
+			<name>%NAME% Version</name>
 			<priority>2</priority>
 			<and_or>and</and_or>
 			<search_type>is not</search_type>

--- a/Zoom/Zoom.jss.recipe
+++ b/Zoom/Zoom.jss.recipe
@@ -13,11 +13,9 @@
 		<key>GROUP_NAME</key>
 		<string>%NAME%-update-smart</string>
 		<key>GROUP_TEMPLATE</key>
-		<string>SmartGroupTemplate.xml</string>
-		<key>JSS_INVENTORY_NAME</key>
-		<string>zoom.us.app</string>
+		<string>CFBundleVersionSmartGroupTemplate.xml</string>
 		<key>NAME</key>
-		<string>Zoom</string>
+		<string>zoom.us</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>
@@ -28,7 +26,7 @@
 		<string>Zoom.png</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.pkg.Zoom</string>
 	<key>Process</key>
@@ -38,6 +36,13 @@
 			<dict>
 				<key>category</key>
 				<string>%CATEGORY%</string>
+				<key>extension_attributes</key>
+				<array>
+					<dict>
+						<key>ext_attribute_path</key>
+						<string>CFBundleVersionExtensionAttribute.xml</string>
+					</dict>
+				</array>
 				<key>groups</key>
 				<array>
 					<dict>
@@ -49,8 +54,6 @@
 						<string>%GROUP_TEMPLATE%</string>
 					</dict>
 				</array>
-				<key>jss_inventory_name</key>
-				<string>%JSS_INVENTORY_NAME%</string>
 				<key>policy_category</key>
 				<string>%POLICY_CATEGORY%</string>
 				<key>policy_template</key>


### PR DESCRIPTION
- changed `GROUP_TEMPLATE` to CFBundleSmartGroupTemplate.xml (Zoom application no longer reports version string in a format compatible with AutoPkg)
- added extension attribute using CFBundleVersionExtensionAttribute.xml
- removed `JSS_INVENTORY_NAME` definition (no longer required with extension attribute addition)
- changed `NAME` to zoom.us to match the application bundle name (so it's compatible with the EA template; alternative would be to make a separate template file just for Zoom to accommodate the app name/product name disparity, but this felt cleaner)
- increased `MinimumVersion` to 1.1 (to match parent recipe)
- added space to computer group name in CFBundleVersionExtensionAttribute.xml for improved legibility