### PR TITLE
Added Mojave for Skitch

### DIFF
--- a/Skitch/Skitch.jss.recipe
+++ b/Skitch/Skitch.jss.recipe
@@ -17,7 +17,7 @@
 		<key>NAME</key>
 		<string>Skitch</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.13.x,10.12.x,10.11.x,10.10.x</string>
+		<string>10.14.x,10.13.x,10.12.x,10.11.x,10.10.x</string>
 		<key>PKG_ID</key>
 		<string>com.skitch.skitch</string>
 		<key>POLICY_CATEGORY</key>


### PR DESCRIPTION
I have conformed Skitch works with macOS 10.14.6, and added 10.14.x to the OS requirements.