### PR TITLE
updated OS_REQUIREMENTS for iWork apps

### DIFF
--- a/Keynote/Keynote.jss.recipe
+++ b/Keynote/Keynote.jss.recipe
@@ -17,7 +17,7 @@
 		<key>NAME</key>
 		<string>Keynote</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.13.x,10.12.x,10.11.x,10.10.x</string>
+		<string>10.14.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>

--- a/Numbers/Numbers.jss.recipe
+++ b/Numbers/Numbers.jss.recipe
@@ -17,7 +17,7 @@
 		<key>NAME</key>
 		<string>Numbers</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.13.x,10.12.x,10.11.x,10.10.x</string>
+		<string>10.14.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>

--- a/Pages/Pages.jss.recipe
+++ b/Pages/Pages.jss.recipe
@@ -17,7 +17,7 @@
 		<key>NAME</key>
 		<string>Pages</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.13.x,10.12.x,10.11.x,10.10.x</string>
+		<string>10.14.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>


### PR DESCRIPTION
All iWork apps now require macOS 10.14 Mojave or later. I know that in the past there's been hesitation to change the OS_REQUIREMENTS since the Mac running AutoPkg may be an older version, but I suspect it would be best to have overrides change the default app requirement as needed to account for differences in local infrastructure.