### PR TITLE
Set OS requirements for Acrobat DC to 10.12+

### DIFF
--- a/Adobe Acrobat DC/Adobe Acrobat DC.jss.recipe
+++ b/Adobe Acrobat DC/Adobe Acrobat DC.jss.recipe
@@ -17,7 +17,7 @@
 		<key>NAME</key>
 		<string>Adobe Acrobat DC</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.15.x,10.14.x,10.13.x,10.12.x,10.11.x,10.10.x,10.9.x</string>
+		<string>10.15.x,10.14.x,10.13.x,10.12.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>


### PR DESCRIPTION
Per Adobe doc: https://helpx.adobe.com/acrobat/system-requirements.html

Follow up to #194.