### PR TITLE
Add 10.15 and 10.14 to package requirements for Bartender and 1Password

### DIFF
--- a/1Password/1Password.jss.recipe
+++ b/1Password/1Password.jss.recipe
@@ -17,7 +17,7 @@
 		<key>NAME</key>
 		<string>1Password</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.14.x,10.13.x,10.12.6</string>
+		<string>10.15.x,10.14.x,10.13.x,10.12.6</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>

--- a/1Password/1Password.jss.recipe
+++ b/1Password/1Password.jss.recipe
@@ -17,7 +17,7 @@
 		<key>NAME</key>
 		<string>1Password</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.15.x,10.14.x,10.13.x,10.12.6</string>
+		<string>10.15.x,10.14.x,10.13.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>

--- a/Bartender/Bartender.jss.recipe
+++ b/Bartender/Bartender.jss.recipe
@@ -17,7 +17,7 @@
 		<key>NAME</key>
 		<string>Bartender</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.13.x,10.12.x,10.11.x,10.10.x</string>
+		<string>10.15.x,10.14.x,10.13.x,10.12.x,10.11.x,10.10.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>

--- a/Bartender/Bartender.jss.recipe
+++ b/Bartender/Bartender.jss.recipe
@@ -17,7 +17,7 @@
 		<key>NAME</key>
 		<string>Bartender</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.15.x,10.14.x,10.13.x,10.12.x,10.11.x,10.10.x</string>
+		<string>10.15.x,10.14.x,10.13.x,10.12.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>


### PR DESCRIPTION
Recently set up a new 10.15 machine, Bartender and 1Password package requirements are out of date.