### PR TITLE
Update Github Desktop OS requirements

### DIFF
--- a/GitHub Desktop/GitHub Desktop.jss.recipe
+++ b/GitHub Desktop/GitHub Desktop.jss.recipe
@@ -17,7 +17,7 @@
 		<key>NAME</key>
 		<string>GitHub Desktop</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.13.x,10.12.x,10.11.x,10.10.x,10.9.x</string>
+		<string>10.15.x,10.14.x,10.13.x,10.12.x,10.11.x,10.10.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>


### PR DESCRIPTION
Added 10.15.x and 10.14.x, and removed 10.9.x, per Github Desktop's current system requirements. https://help.github.com/en/desktop/getting-started-with-github-desktop/installing-github-desktop