### PR TITLE
AdobeReaderDC:  Removed the `PkgCopier` Step

### DIFF
--- a/Adobe Acrobat Reader DC/Adobe Acrobat Reader DC.jss.recipe
+++ b/Adobe Acrobat Reader DC/Adobe Acrobat Reader DC.jss.recipe
@@ -36,17 +36,6 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
-				<key>source_pkg</key>
-				<string>%pkg_path%</string>
-			</dict>
-			<key>Processor</key>
-			<string>PkgCopier</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>category</key>
 				<string>%CATEGORY%</string>
 				<key>groups</key>


### PR DESCRIPTION
Removed the `PkgCopier` Step from the recipe as it doesn't appear needed...and is failing to copy for me.  Taking it out, the recipe successfully completes.

If I'm missing something, feel free to let me know...