### PR TITLE
Update OS_REQUIREMENTS

### DIFF
--- a/GitHub Desktop/GitHub Desktop.jss.recipe
+++ b/GitHub Desktop/GitHub Desktop.jss.recipe
@@ -17,7 +17,7 @@
 		<key>NAME</key>
 		<string>GitHub Desktop</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.16.x,10.15.x,10.14.x,10.13.x,10.12.x,10.11.x,10.10.x</string>
+		<string>11.x,10.16.x,10.15.x,10.14.x,10.13.x,10.12.x,10.11.x,10.10.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>


### PR DESCRIPTION
Add `11.x` to `OS_REQUIREMENTS` to support Jamf 10.26+.