### PR TITLE
Deprecate obsolete recipes and update validation script

### DIFF
--- a/AdobeFlashPlayer/AdobeFlashPlayer.jss.recipe
+++ b/AdobeFlashPlayer/AdobeFlashPlayer.jss.recipe
@@ -26,11 +26,15 @@
 		<string>AdobeFlashPlayer.png</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.4.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.autopkg.pkg.FlashPlayerExtractPackage</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Docker Toolbox/Docker Toolbox.jss.recipe
+++ b/Docker Toolbox/Docker Toolbox.jss.recipe
@@ -26,11 +26,15 @@
 		<string>Docker Toolbox.png</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.4.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.homebysix.pkg.DockerToolbox</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Office2011Update/Office2011Update-DisabledAllQuit.jss.recipe
+++ b/Office2011Update/Office2011Update-DisabledAllQuit.jss.recipe
@@ -26,11 +26,15 @@
 		<string>Office2011Update.png</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.4.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.sheagcraig.pkg.Office2011UpdatesDisabledAllQuit</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
 		<dict>
 			<key>Processor</key>
 			<string>Office2011UpdateVersioner</string>

--- a/Office2011Update/Office2011Update.jss.recipe
+++ b/Office2011Update/Office2011Update.jss.recipe
@@ -26,11 +26,15 @@
 		<string>Office2011Update.png</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.4.0</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.autopkg.pkg.Office2011Updates</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
 		<dict>
 			<key>Processor</key>
 			<string>Office2011UpdateVersioner</string>

--- a/validate_recipes.py
+++ b/validate_recipes.py
@@ -236,8 +236,14 @@ def validate_recipe(recipe_path, verbose=False):
 
     if os.path.exists(recipe_path):
         recipe = get_recipe(recipe_path)
+        # Skip exempted recipes.
         if recipe["Identifier"] in EXEMPTED_RECIPES:
             print("Recipe is exempted from validation.")
+            return
+        # Skip deprecated recipes.
+        proc_names = [x.get("Processor") for x in recipe.get("Process", [{}])]
+        if "DeprecationWarning" in proc_names:
+            print("Recipe is deprecated.")
             return
     else:
         print("File not found.")

--- a/validate_recipes.py
+++ b/validate_recipes.py
@@ -37,7 +37,7 @@ from Foundation import (
 # pylint: enable=no-name-in-module
 
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 REQUIRED_ARGUMENTS = (
     "self_service_description",

--- a/validate_recipes.py
+++ b/validate_recipes.py
@@ -70,6 +70,7 @@ EXEMPTED_RECIPES = [
     "com.github.jss-recipes.jss.MicrosoftOneNote",  # extra processors for versioning
     "com.github.jss-recipes.jss.MicrosoftOutlook",  # extra processors for versioning
     "com.github.jss-recipes.jss.MicrosoftWord",  # extra processors for versioning
+    "com.github.jss-recipes.jss.MicrosoftPowerPoint",  # extra processors for versioning
     "com.github.jss-recipes.jss.MicrosoftExcel",  # extra processors for versioning
 ]
 


### PR DESCRIPTION
Docker Toolbox, Adobe Flash Player, and Microsoft Office 2011 are no longer maintained, and therefore their jss recipes are no longer useful. Will remove the recipes from the repo at a later date.

Also updated the validator script to skip deprecated recipes and include PowerPoint alongside its other Office exemptions, due to having more than just the JSSImporter processor.