### PR TITLE
added PLATFORM_ARCH note

### DIFF
--- a/Parallels Desktop/Parallels Desktop.jss.recipe
+++ b/Parallels Desktop/Parallels Desktop.jss.recipe
@@ -3,7 +3,11 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the version of Parallels Desktop specified in MAJOR_VERSION and imports it into your JSS.</string>
+	<string>Downloads the major version of Parallels Desktop specified by MAJOR_VERSION, creates a package, and imports it into your JSS. This recipe has been tested with major versions 9 through 16.
+
+For major versions 9 through 15, leave the PLATFORM_ARCH blank in your override.
+
+For major version 16, set the PLATFORM_ARCH in your override to either "intel" or "m1" depending on your desired architecture.</string>
 	<key>Identifier</key>
 	<string>com.github.jss-recipes.jss.ParallelsDesktop</string>
 	<key>Input</key>
@@ -14,12 +18,8 @@
 		<string>%NAME%-update-smart</string>
 		<key>GROUP_TEMPLATE</key>
 		<string>SmartGroupTemplate.xml</string>
-		<key>MAJOR_VERSION</key>
-		<string>15</string>
 		<key>NAME</key>
 		<string>Parallels Desktop</string>
-		<key>OS_REQUIREMENTS</key>
-		<string>10.15.x,10.14.x,10.13.x,10.12.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>


### PR DESCRIPTION
- added `PLATFORM_ARCH` note to description to match [upstream recipe changes](https://github.com/autopkg/homebysix-recipes/pull/408), as a Parallels recipe with major version 15 doesn't work if you specify `PLATFORM_ARCH`, and major version 16 doesn't work if you _omit_ `PLATFORM_ARCH`
- removed `MAJOR_VERSION` and `OS_REQUIREMENTS` input variables