### PR TITLE
Adjust parent recipes for sheagcraig-recipes repo deprecation

### DIFF
--- a/AirServer/AirServer.jss.recipe
+++ b/AirServer/AirServer.jss.recipe
@@ -32,7 +32,7 @@
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.sheagcraig.pkg.AirServer</string>
+	<string>com.github.homebysix.pkg.AirServer</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Eclipse/Eclipse-Luna.jss.recipe
+++ b/Eclipse/Eclipse-Luna.jss.recipe
@@ -32,7 +32,7 @@
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.sheagcraig.pkg.EclipseLuna</string>
+	<string>com.github.homebysix.pkg.EclipseLuna</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/GSP5/GSP5.jss.recipe
+++ b/GSP5/GSP5.jss.recipe
@@ -32,7 +32,7 @@
 	<key>MinimumVersion</key>
 	<string>0.2.5</string>
 	<key>ParentRecipe</key>
-	<string>com.github.sheagcraig.pkg.GSP5</string>
+	<string>com.github.homebysix.pkg.GSP5</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Jin/Jin.jss.recipe
+++ b/Jin/Jin.jss.recipe
@@ -34,7 +34,7 @@
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.sheagcraig.pkg.Jin</string>
+	<string>com.github.homebysix.pkg.Jin</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/OpenEmu/OpenEmu.jss.recipe
+++ b/OpenEmu/OpenEmu.jss.recipe
@@ -28,7 +28,7 @@
 	<key>MinimumVersion</key>
 	<string>0.2.5</string>
 	<key>ParentRecipe</key>
-	<string>com.github.sheagcraig.pkg.OpenEmu</string>
+	<string>com.github.homebysix.pkg.OpenEmu</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/VirtualBox/VirtualBox.jss.recipe
+++ b/VirtualBox/VirtualBox.jss.recipe
@@ -28,7 +28,7 @@
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.sheagcraig.pkg.VirtualBox</string>
+	<string>com.github.homebysix.pkg.VirtualBox</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/jss_helper/jss_helper.jss.recipe
+++ b/jss_helper/jss_helper.jss.recipe
@@ -28,7 +28,7 @@
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.sheagcraig.download.jss_helper</string>
+	<string>com.github.homebysix.download.jss_helper</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/yo/yo.jss.recipe
+++ b/yo/yo.jss.recipe
@@ -28,7 +28,7 @@
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.sheagcraig.download.yo</string>
+	<string>com.github.homebysix.download.yo</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
The sheagcraig-recipes repository is being deprecated (details here: https://github.com/autopkg/sheagcraig-recipes/issues/71). Many working and/or serviceable recipes have already been [copied](https://github.com/autopkg/homebysix-recipes/pull/414) to the homebysix-recipes repo. This PR changes the parent recipes in your repo to point to the homebysix-recipes version of any affected recipes.

In addition to updating trust info, users of the changed recipes will need to ensure the homebysix-recipes repo is added to their AutoPkg environment (`autopkg repo-add homebysix-recipes`).