### PR TITLE
Update app requirements and make Big Sur version syntax consistent

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.3.0
+  rev: v4.0.1
   hooks:
   - id: check-added-large-files
     args: [--maxkb=100]
@@ -14,11 +14,11 @@ repos:
   - id: trailing-whitespace
     args: [--markdown-linebreak-ext=md]
 - repo: https://github.com/python/black
-  rev: 20.8b1
+  rev: 21.5b1
   hooks:
   - id: black
 - repo: https://github.com/homebysix/pre-commit-macadmin
-  rev: v1.8.0
+  rev: v1.10.1
   hooks:
   - id: check-autopkg-recipes
   - id: forbid-autopkg-overrides

--- a/1Password/1Password.jss.recipe
+++ b/1Password/1Password.jss.recipe
@@ -17,7 +17,7 @@
 		<key>NAME</key>
 		<string>1Password</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.15.x,10.14.x,10.13.x</string>
+		<string>11.x,10.16.x,10.15.x,10.14.x,10.13.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>

--- a/Firefox/Firefox.jss.recipe
+++ b/Firefox/Firefox.jss.recipe
@@ -23,7 +23,7 @@ combination is offered.</string>
 		<key>NAME</key>
 		<string>Firefox</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.16.x,10.15.x,10.14.x,10.13.x,10.12.x</string>
+		<string>11.x,10.16.x,10.15.x,10.14.x,10.13.x,10.12.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>

--- a/GarageBand/GarageBand.jss.recipe
+++ b/GarageBand/GarageBand.jss.recipe
@@ -17,7 +17,7 @@
 		<key>NAME</key>
 		<string>GarageBand</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.11.x,10.10.x,10.9.x</string>
+		<string>11.x,10.16.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>

--- a/Google Chrome/Google Chrome.jss.recipe
+++ b/Google Chrome/Google Chrome.jss.recipe
@@ -17,7 +17,7 @@
 		<key>NAME</key>
 		<string>Google Chrome</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.16.x,10.15.x,10.14.x,10.13.x,10.12.x,10.11.x,10.10.x</string>
+		<string>11.x,10.16.x,10.15.x,10.14.x,10.13.x,10.12.x,10.11.x,10.10.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>

--- a/Keynote/Keynote.jss.recipe
+++ b/Keynote/Keynote.jss.recipe
@@ -17,7 +17,7 @@
 		<key>NAME</key>
 		<string>Keynote</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.15.x,10.14.x</string>
+		<string>11.x,10.16.x,10.15.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>

--- a/Microsoft Remote Desktop/Microsoft Remote Desktop.jss.recipe
+++ b/Microsoft Remote Desktop/Microsoft Remote Desktop.jss.recipe
@@ -17,7 +17,7 @@
 		<key>NAME</key>
 		<string>Microsoft Remote Desktop</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.16.x,10.15.x,10.14.x,10.13.x</string>
+		<string>11.x,10.16.x,10.15.x,10.14.x,10.13.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>

--- a/Numbers/Numbers.jss.recipe
+++ b/Numbers/Numbers.jss.recipe
@@ -17,7 +17,7 @@
 		<key>NAME</key>
 		<string>Numbers</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.15.x,10.14.x</string>
+		<string>11.x,10.16.x,10.15.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>

--- a/OmniFocus/OmniFocus.jss.recipe
+++ b/OmniFocus/OmniFocus.jss.recipe
@@ -21,7 +21,7 @@ To get the most current version of OmniFocus, override these two input variables
 		<key>NAME</key>
 		<string>OmniFocus</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.11.x,10.10.x</string>
+		<string>11.x,10.16.x,10.15.x,10.14.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>

--- a/OmniGraffle/OmniGraffle.jss.recipe
+++ b/OmniGraffle/OmniGraffle.jss.recipe
@@ -21,7 +21,7 @@ To get the most current version of OmniGraffle, override these two input variabl
 		<key>NAME</key>
 		<string>OmniGraffle</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.11.x,10.10.x</string>
+		<string>11.x,10.16.x,10.15.x,10.14.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>

--- a/OmniOutliner/OmniOutliner.jss.recipe
+++ b/OmniOutliner/OmniOutliner.jss.recipe
@@ -21,7 +21,7 @@ To get the most current version of OmniOutliner, override these two input variab
 		<key>NAME</key>
 		<string>OmniOutliner</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.11.x,10.10.x</string>
+		<string>11.x,10.16.x,10.15.x,10.14.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>

--- a/OmniPlan/OmniPlan.jss.recipe
+++ b/OmniPlan/OmniPlan.jss.recipe
@@ -21,7 +21,7 @@ To get the most current version of OmniPlan, override these two input variables:
 		<key>NAME</key>
 		<string>OmniPlan</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.11.x,10.10.x</string>
+		<string>11.x,10.16.x,10.15.x,10.14.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>

--- a/Pages/Pages.jss.recipe
+++ b/Pages/Pages.jss.recipe
@@ -17,7 +17,7 @@
 		<key>NAME</key>
 		<string>Pages</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.15.x,10.14.x</string>
+		<string>11.x,10.16.x,10.15.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>

--- a/Skype/Skype.jss.recipe
+++ b/Skype/Skype.jss.recipe
@@ -17,7 +17,7 @@
 		<key>NAME</key>
 		<string>Skype</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.15.x,10.14.x,10.13.x,10.12.x,10.11.x,10.10.x,10.9.x</string>
+		<string>11.x,10.16.x,10.15.x,10.14.x,10.13.x,10.12.x,10.11.x,10.10.x,10.9.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>

--- a/Xcode/Xcode.jss.recipe
+++ b/Xcode/Xcode.jss.recipe
@@ -17,7 +17,7 @@
 		<key>NAME</key>
 		<string>Xcode</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.13.x,10.12.x,10.11.x,10.10.x</string>
+		<string>11.x,10.16.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>

--- a/coconutBattery/coconutBattery.jss.recipe
+++ b/coconutBattery/coconutBattery.jss.recipe
@@ -17,7 +17,7 @@
 		<key>NAME</key>
 		<string>coconutBattery</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.13.x,10.12.x,10.11.x</string>
+		<string>11.x,10.16.x,10.15.x,10.14.x,10.13.x,10.12.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>

--- a/iMovie/iMovie.jss.recipe
+++ b/iMovie/iMovie.jss.recipe
@@ -17,7 +17,7 @@
 		<key>NAME</key>
 		<string>iMovie</string>
 		<key>OS_REQUIREMENTS</key>
-		<string>10.11.x,10.10.x</string>
+		<string>11.x,10.16.x,10.15.x</string>
 		<key>POLICY_CATEGORY</key>
 		<string>Testing</string>
 		<key>POLICY_TEMPLATE</key>


### PR DESCRIPTION
Specify `11.x,10.16.x` for Big Sur, and update OS requirements for selected apps.