### PR TITLE
Update parent recipe due to deprecation

### DIFF
--- a/Comic Life 3/Comic Life 3.jss.recipe
+++ b/Comic Life 3/Comic Life 3.jss.recipe
@@ -32,7 +32,7 @@
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.sheagcraig.pkg.ComicLife3</string>
+	<string>com.github.tallfunnyjew.pkg.ComicLife3</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
"The sheagcraig-recipes repository is deprecated.
Details: https://github.com/autopkg/sheagcraig-recipes/issues/71
Alternative ComicLife3 recipes exist in the tallfunnyjew-recipes repository."